### PR TITLE
Bugfix for automatic character width detection. Less garbage.

### DIFF
--- a/good.log
+++ b/good.log
@@ -5040,16 +5040,16 @@ Patching...
    method signature (Lnet/minecraft/src/FontRenderer;C)F -> (Lnl;C)F
    method signature (Lnet/minecraft/src/FontRenderer;Ljava/lang/String;)F -> (Lnl;Ljava/lang/String;)F
     method ref net.minecraft.src.FontRenderer.getCharWidth (C)I -> nl.a (C)I getCharWidthf(Lnl;C)F@2
-     INVOKEVIRTUAL 0x00 0x14   INVOKEVIRTUAL 0x01 0x49
-    method ref net.minecraft.src.FontRenderer.getCharWidth (C)I -> nl.a (C)I getStringWidthf(Lnl;Ljava/lang/String;)F@29
-     INVOKEVIRTUAL 0x00 0x14   INVOKEVIRTUAL 0x01 0x49
-    method ref net.minecraft.src.FontRenderer.getCharWidth (C)I -> nl.a (C)I getStringWidthf(Lnl;Ljava/lang/String;)F@101
-     INVOKEVIRTUAL 0x00 0x14   INVOKEVIRTUAL 0x01 0x49
+     INVOKEVIRTUAL 0x00 0x15   INVOKEVIRTUAL 0x01 0x4a
+    method ref net.minecraft.src.FontRenderer.getCharWidth (C)I -> nl.a (C)I getStringWidthf(Lnl;Ljava/lang/String;)F@31
+     INVOKEVIRTUAL 0x00 0x15   INVOKEVIRTUAL 0x01 0x4a
+    method ref net.minecraft.src.FontRenderer.getCharWidth (C)I -> nl.a (C)I getStringWidthf(Lnl;Ljava/lang/String;)F@145
+     INVOKEVIRTUAL 0x00 0x15   INVOKEVIRTUAL 0x01 0x4a
     field ref net.minecraft.src.FontRenderer.charWidthf [F -> nl.charWidthf [F getCharWidthf(Lnl;C)F@15
-     GETFIELD 0x00 0x15        GETFIELD 0x01 0x4a
+     GETFIELD 0x00 0x16        GETFIELD 0x01 0x4b
     field ref net.minecraft.src.FontRenderer.charWidthf [F -> nl.charWidthf [F getCharWidthf(Lnl;C)F@29
-     GETFIELD 0x00 0x15        GETFIELD 0x01 0x4a
-   string replace Lnet/minecraft/src/FontRenderer; -> Lnl; @1289
+     GETFIELD 0x00 0x16        GETFIELD 0x01 0x4b
+   string replace Lnet/minecraft/src/FontRenderer; -> Lnl; @1294
   adding com/pclewis/mcpatcher/mod/MobRandomizer.class for Random Mobs
    method signature (Lnet/minecraft/src/Entity;)Ljava/lang/String; -> (Lnn;)Ljava/lang/String;
    method signature (Lnet/minecraft/src/Entity;Ljava/lang/String;)Ljava/lang/String; -> (Lnn;Ljava/lang/String;)Ljava/lang/String;
@@ -5367,23 +5367,23 @@ Patching...
    field signature Lnet/minecraft/src/TexturePackBase; -> Lh;
    field signature Lnet/minecraft/src/Tessellator; -> Ladz;
     field ref net.minecraft.src.Tessellator.instance Lnet/minecraft/src/Tessellator; -> adz.a Ladz; start()V@3
-     GETSTATIC 0x00 0x03       GETSTATIC 0x01 0x98
+     GETSTATIC 0x00 0x03       GETSTATIC 0x01 0x9a
     field ref net.minecraft.src.Tessellator.instance Lnet/minecraft/src/Tessellator; -> adz.a Ladz; start()V@12
-     GETSTATIC 0x00 0x03       GETSTATIC 0x01 0x98
+     GETSTATIC 0x00 0x03       GETSTATIC 0x01 0x9a
     field ref net.minecraft.src.Tessellator.instance Lnet/minecraft/src/Tessellator; -> adz.a Ladz; setup(Lpb;Lali;IIIII)Z@56
-     GETSTATIC 0x00 0x03       GETSTATIC 0x01 0x98
+     GETSTATIC 0x00 0x03       GETSTATIC 0x01 0x9a
     field ref net.minecraft.src.Tessellator.instance Lnet/minecraft/src/Tessellator; -> adz.a Ladz; setup(Lpb;Lali;IIII)Z@44
-     GETSTATIC 0x00 0x03       GETSTATIC 0x01 0x98
+     GETSTATIC 0x00 0x03       GETSTATIC 0x01 0x9a
     field ref net.minecraft.src.Tessellator.instance Lnet/minecraft/src/Tessellator; -> adz.a Ladz; finish()V@3
-     GETSTATIC 0x00 0x03       GETSTATIC 0x01 0x98
+     GETSTATIC 0x00 0x03       GETSTATIC 0x01 0x9a
     field ref net.minecraft.src.Tessellator.instance Lnet/minecraft/src/Tessellator; -> adz.a Ladz; checkUpdate()V@39
-     GETSTATIC 0x00 0x03       GETSTATIC 0x01 0x98
+     GETSTATIC 0x00 0x03       GETSTATIC 0x01 0x9a
     field ref net.minecraft.src.Tessellator.instance Lnet/minecraft/src/Tessellator; -> adz.a Ladz; checkUpdate()V@48
-     GETSTATIC 0x00 0x03       GETSTATIC 0x01 0x98
+     GETSTATIC 0x00 0x03       GETSTATIC 0x01 0x9a
     field ref net.minecraft.src.Tessellator.texture I -> adz.texture I start()V@9
-     PUTFIELD 0x00 0x05        PUTFIELD 0x01 0x99
+     PUTFIELD 0x00 0x05        PUTFIELD 0x01 0x9b
     field ref net.minecraft.src.Tessellator.texture I -> adz.texture I finish()V@7
-     PUTFIELD 0x00 0x05        PUTFIELD 0x01 0x99
+     PUTFIELD 0x00 0x05        PUTFIELD 0x01 0x9b
     class ref com.pclewis.mcpatcher.mod.SuperTessellator -> com/pclewis/mcpatcher/mod/SuperTessellator start()V@15
      INSTANCEOF 0x00 0x06      INSTANCEOF 0x00 0x06
     class ref com.pclewis.mcpatcher.mod.SuperTessellator -> com/pclewis/mcpatcher/mod/SuperTessellator setup(Lpb;Lali;IIIII)Z@59
@@ -5395,57 +5395,57 @@ Patching...
     class ref com.pclewis.mcpatcher.mod.SuperTessellator -> com/pclewis/mcpatcher/mod/SuperTessellator checkUpdate()V@51
      CHECKCAST 0x00 0x06       CHECKCAST 0x00 0x06
     field ref net.minecraft.src.Block.blockID I -> pb.bO I setup(Lpb;Lali;IIIII)Z@30
-     GETFIELD 0x00 0x09        GETFIELD 0x01 0x9e
+     GETFIELD 0x00 0x09        GETFIELD 0x01 0xa0
     field ref net.minecraft.src.Block.blockID I -> pb.bO I setup(Lpb;Lali;IIII)Z@19
-     GETFIELD 0x00 0x09        GETFIELD 0x01 0x9e
-    field ref net.minecraft.src.Block.blockID I -> pb.bO I getConnectedTexture(Lali;Lpb;IIIII)Z@14
-     GETFIELD 0x00 0x09        GETFIELD 0x01 0x9e
+     GETFIELD 0x00 0x09        GETFIELD 0x01 0xa0
+    field ref net.minecraft.src.Block.blockID I -> pb.bO I getConnectedTexture(Lali;Lpb;IIIII)Z@34
+     GETFIELD 0x00 0x09        GETFIELD 0x01 0xa0
     method ref com.pclewis.mcpatcher.mod.CTMUtils.getConnectedTexture (Lnet/minecraft/src/IBlockAccess;Lnet/minecraft/src/Block;IIIII)Z -> com.pclewis.mcpatcher.mod.CTMUtils.getConnectedTexture (Lali;Lpb;IIIII)Z setup(Lpb;Lali;IIIII)Z@50
-     INVOKESTATIC 0x00 0x0a    INVOKESTATIC 0x01 0xa0
+     INVOKESTATIC 0x00 0x0a    INVOKESTATIC 0x01 0xa2
     method ref com.pclewis.mcpatcher.mod.CTMUtils.getConnectedTexture (Lnet/minecraft/src/IBlockAccess;Lnet/minecraft/src/Block;IIIII)Z -> com.pclewis.mcpatcher.mod.CTMUtils.getConnectedTexture (Lali;Lpb;IIIII)Z setup(Lpb;Lali;IIII)Z@38
-     INVOKESTATIC 0x00 0x0a    INVOKESTATIC 0x01 0xa0
+     INVOKESTATIC 0x00 0x0a    INVOKESTATIC 0x01 0xa2
     method ref com.pclewis.mcpatcher.mod.SuperTessellator.getTessellator (I)Lnet/minecraft/src/Tessellator; -> com/pclewis/mcpatcher/mod/SuperTessellator.getTessellator (I)Ladz; setup(Lpb;Lali;IIIII)Z@65
-     INVOKEVIRTUAL 0x00 0x0c   INVOKEVIRTUAL 0x01 0xa3
+     INVOKEVIRTUAL 0x00 0x0c   INVOKEVIRTUAL 0x01 0xa5
     method ref com.pclewis.mcpatcher.mod.SuperTessellator.getTessellator (I)Lnet/minecraft/src/Tessellator; -> com/pclewis/mcpatcher/mod/SuperTessellator.getTessellator (I)Ladz; setup(Lpb;Lali;IIII)Z@53
-     INVOKEVIRTUAL 0x00 0x0c   INVOKEVIRTUAL 0x01 0xa3
+     INVOKEVIRTUAL 0x00 0x0c   INVOKEVIRTUAL 0x01 0xa5
     field ref com.pclewis.mcpatcher.mod.CTMUtils.newTessellator Lnet/minecraft/src/Tessellator; -> com.pclewis.mcpatcher.mod.CTMUtils.newTessellator Ladz; setup(Lpb;Lali;IIIII)Z@68
-     PUTSTATIC 0x00 0x0d       PUTSTATIC 0x01 0xa5
+     PUTSTATIC 0x00 0x0d       PUTSTATIC 0x01 0xa7
     field ref com.pclewis.mcpatcher.mod.CTMUtils.newTessellator Lnet/minecraft/src/Tessellator; -> com.pclewis.mcpatcher.mod.CTMUtils.newTessellator Ladz; setup(Lpb;Lali;IIII)Z@56
-     PUTSTATIC 0x00 0x0d       PUTSTATIC 0x01 0xa5
-    method ref com.pclewis.mcpatcher.mod.CTMUtils.getConnectedTexture (Lnet/minecraft/src/IBlockAccess;Lnet/minecraft/src/Block;IIIII[Lcom/pclewis/mcpatcher/mod/TileOverride;I)Z -> com.pclewis.mcpatcher.mod.CTMUtils.getConnectedTexture (Lali;Lpb;IIIII[Lcom/pclewis/mcpatcher/mod/TileOverride;I)Z getConnectedTexture(Lali;Lpb;IIIII)Z@17
-     INVOKESTATIC 0x00 0x11    INVOKESTATIC 0x01 0xa7
+     PUTSTATIC 0x00 0x0d       PUTSTATIC 0x01 0xa7
+    method ref com.pclewis.mcpatcher.mod.CTMUtils.getConnectedTexture (Lnet/minecraft/src/IBlockAccess;Lnet/minecraft/src/Block;IIIII[Lcom/pclewis/mcpatcher/mod/TileOverride;I)Z -> com.pclewis.mcpatcher.mod.CTMUtils.getConnectedTexture (Lali;Lpb;IIIII[Lcom/pclewis/mcpatcher/mod/TileOverride;I)Z getConnectedTexture(Lali;Lpb;IIIII)Z@14
+     INVOKESTATIC 0x00 0x11    INVOKESTATIC 0x01 0xa9
     method ref com.pclewis.mcpatcher.mod.CTMUtils.getConnectedTexture (Lnet/minecraft/src/IBlockAccess;Lnet/minecraft/src/Block;IIIII[Lcom/pclewis/mcpatcher/mod/TileOverride;I)Z -> com.pclewis.mcpatcher.mod.CTMUtils.getConnectedTexture (Lali;Lpb;IIIII[Lcom/pclewis/mcpatcher/mod/TileOverride;I)Z getConnectedTexture(Lali;Lpb;IIIII)Z@37
-     INVOKESTATIC 0x00 0x11    INVOKESTATIC 0x01 0xa7
+     INVOKESTATIC 0x00 0x11    INVOKESTATIC 0x01 0xa9
     method ref com.pclewis.mcpatcher.mod.TileOverride.getTile (Lnet/minecraft/src/IBlockAccess;Lnet/minecraft/src/Block;IIIII)I -> com.pclewis.mcpatcher.mod.TileOverride.getTile (Lali;Lpb;IIIII)I getConnectedTexture(Lali;Lpb;IIIII[Lcom/pclewis/mcpatcher/mod/TileOverride;I)Z@65
-     INVOKEVIRTUAL 0x00 0x15   INVOKEVIRTUAL 0x01 0xaa
+     INVOKEVIRTUAL 0x00 0x15   INVOKEVIRTUAL 0x01 0xac
     field ref net.minecraft.client.Minecraft.texturePackList Lnet/minecraft/src/TexturePackList; -> net/minecraft/client/Minecraft.E Lgi; checkUpdate()V@3
-     GETFIELD 0x00 0x18        GETFIELD 0x01 0xae
+     GETFIELD 0x00 0x18        GETFIELD 0x01 0xb0
     method ref net.minecraft.src.TexturePackList.getSelectedTexturePack ()Lnet/minecraft/src/TexturePackBase; -> gi.getSelectedTexturePack ()Lh; checkUpdate()V@6
-     INVOKEVIRTUAL 0x00 0x19   INVOKEVIRTUAL 0x01 0xb3
+     INVOKEVIRTUAL 0x00 0x19   INVOKEVIRTUAL 0x01 0xb5
     field ref com.pclewis.mcpatcher.mod.CTMUtils.lastTexturePack Lnet/minecraft/src/TexturePackBase; -> com.pclewis.mcpatcher.mod.CTMUtils.lastTexturePack Lh; checkUpdate()V@11
-     GETSTATIC 0x00 0x1a       GETSTATIC 0x01 0xb5
+     GETSTATIC 0x00 0x1a       GETSTATIC 0x01 0xb7
     field ref com.pclewis.mcpatcher.mod.CTMUtils.lastTexturePack Lnet/minecraft/src/TexturePackBase; -> com.pclewis.mcpatcher.mod.CTMUtils.lastTexturePack Lh; checkUpdate()V@28
-     PUTSTATIC 0x00 0x1a       PUTSTATIC 0x01 0xb5
+     PUTSTATIC 0x00 0x1a       PUTSTATIC 0x01 0xb7
     field ref com.pclewis.mcpatcher.mod.CTMUtils.lastTexturePack Lnet/minecraft/src/TexturePackBase; -> com.pclewis.mcpatcher.mod.CTMUtils.lastTexturePack Lh; setupOutline()V@0
-     GETSTATIC 0x00 0x1a       GETSTATIC 0x01 0xb5
+     GETSTATIC 0x00 0x1a       GETSTATIC 0x01 0xb7
     field ref com.pclewis.mcpatcher.mod.CTMUtils.lastTexturePack Lnet/minecraft/src/TexturePackBase; -> com.pclewis.mcpatcher.mod.CTMUtils.lastTexturePack Lh; setupOutline()V@17
-     GETSTATIC 0x00 0x1a       GETSTATIC 0x01 0xb5
+     GETSTATIC 0x00 0x1a       GETSTATIC 0x01 0xb7
     field ref com.pclewis.mcpatcher.mod.CTMUtils.lastTexturePack Lnet/minecraft/src/TexturePackBase; -> com.pclewis.mcpatcher.mod.CTMUtils.lastTexturePack Lh; getTexture(Ljava/lang/String;)I@6
-     GETSTATIC 0x00 0x1a       GETSTATIC 0x01 0xb5
+     GETSTATIC 0x00 0x1a       GETSTATIC 0x01 0xb7
     method ref com.pclewis.mcpatcher.mod.SuperTessellator.clearTessellators ()V -> com/pclewis/mcpatcher/mod/SuperTessellator.clearTessellators ()V checkUpdate()V@54
      INVOKEVIRTUAL 0x00 0x20   INVOKEVIRTUAL 0x00 0x20
     field ref net.minecraft.src.Block.blocksList [Lnet/minecraft/src/Block; -> pb.m [Lpb; refreshBlockTextures()V@0
-     GETSTATIC 0x00 0x24       GETSTATIC 0x01 0xb9
+     GETSTATIC 0x00 0x24       GETSTATIC 0x01 0xbb
     method ref net.minecraft.src.TexturePackBase.getInputStream (Ljava/lang/String;)Ljava/io/InputStream; -> h.a (Ljava/lang/String;)Ljava/io/InputStream; setupOutline()V@5
-     INVOKEVIRTUAL 0x00 0x41   INVOKEVIRTUAL 0x01 0xbd
+     INVOKEVIRTUAL 0x00 0x41   INVOKEVIRTUAL 0x01 0xbf
     method ref net.minecraft.src.TexturePackBase.getInputStream (Ljava/lang/String;)Ljava/io/InputStream; -> h.a (Ljava/lang/String;)Ljava/io/InputStream; setupOutline()V@22
-     INVOKEVIRTUAL 0x00 0x41   INVOKEVIRTUAL 0x01 0xbd
+     INVOKEVIRTUAL 0x00 0x41   INVOKEVIRTUAL 0x01 0xbf
     method ref net.minecraft.src.TexturePackBase.getInputStream (Ljava/lang/String;)Ljava/io/InputStream; -> h.a (Ljava/lang/String;)Ljava/io/InputStream; getTexture(Ljava/lang/String;)I@10
-     INVOKEVIRTUAL 0x00 0x41   INVOKEVIRTUAL 0x01 0xbd
+     INVOKEVIRTUAL 0x00 0x41   INVOKEVIRTUAL 0x01 0xbf
     field ref net.minecraft.client.Minecraft.renderEngine Lnet/minecraft/src/RenderEngine; -> net/minecraft/client/Minecraft.p Laaw; getTexture(Ljava/lang/String;)I@26
-     GETFIELD 0x00 0x4f        GETFIELD 0x01 0xc1
+     GETFIELD 0x00 0x4f        GETFIELD 0x01 0xc3
     method ref net.minecraft.src.RenderEngine.getTexture (Ljava/lang/String;)I -> aaw.b (Ljava/lang/String;)I getTexture(Ljava/lang/String;)I@30
-     INVOKEVIRTUAL 0x00 0x50   INVOKEVIRTUAL 0x01 0xc5
+     INVOKEVIRTUAL 0x00 0x50   INVOKEVIRTUAL 0x01 0xc7
    string replace Lnet/minecraft/src/Block; -> Lpb; @411
    string replace Lnet/minecraft/src/TexturePackBase; -> Lh; @1169
    string replace Lnet/minecraft/src/IBlockAccess; -> Lali; @432
@@ -5625,9 +5625,9 @@ Patching...
   adding com/pclewis/mcpatcher/mod/TileOverride$CTM.class for Connected Textures
    method signature (Lnet/minecraft/src/IBlockAccess;Lnet/minecraft/src/Block;IIIII)I -> (Lali;Lpb;IIIII)I
     method ref com.pclewis.mcpatcher.mod.TileOverride$CTM.shouldConnect (Lnet/minecraft/src/IBlockAccess;Lnet/minecraft/src/Block;IIIII[I)Z -> com.pclewis.mcpatcher.mod.TileOverride$CTM.shouldConnect (Lali;Lpb;IIIII[I)Z getTileImpl(Lali;Lpb;IIIII)I@38
-     INVOKEVIRTUAL 0x00 0x0c   INVOKEVIRTUAL 0x00 0x5e
-   string replace Lnet/minecraft/src/Block; -> Lpb; @903
-   string replace Lnet/minecraft/src/IBlockAccess; -> Lali; @860
+     INVOKEVIRTUAL 0x00 0x0c   INVOKEVIRTUAL 0x00 0x60
+   string replace Lnet/minecraft/src/Block; -> Lpb; @924
+   string replace Lnet/minecraft/src/IBlockAccess; -> Lali; @881
   adding com/pclewis/mcpatcher/mod/TileOverride$Random1.class for Connected Textures
    method signature (Lnet/minecraft/src/IBlockAccess;Lnet/minecraft/src/Block;IIIII)I -> (Lali;Lpb;IIIII)I
    string replace Lnet/minecraft/src/Block; -> Lpb; @1243

--- a/newcode/src/com/pclewis/mcpatcher/mod/FontUtils.java
+++ b/newcode/src/com/pclewis/mcpatcher/mod/FontUtils.java
@@ -72,6 +72,8 @@ public class FontUtils {
         for (int ch = 0; ch < charWidthf.length; ch++) {
             if (charWidthf[ch] <= 0.0f) {
                 charWidthf[ch] = 2.0f;
+            } else if (charWidthf[ch] >= 7.99f) {
+                charWidthf[ch] = 7.99f;
             }
             else if (charWidthf[ch] <= 7.99f) {
                 charWidthf[ch] = 7.99f;	
@@ -107,9 +109,9 @@ public class FontUtils {
     public static float getStringWidthf(FontRenderer fontRenderer, String s) {
         float totalWidth = 0.0f;
         if (s != null) {
+            boolean isLink = false;
             for (int i = 0; i < s.length(); i++) {
                 char c = s.charAt(i);
-                boolean isLink = false;
                 float cWidth = fontRenderer.getCharWidth(c);
                 if (cWidth < 0.0f && i < s.length() - 1) {
                     c = s.charAt(i + 1);
@@ -135,9 +137,7 @@ public class FontUtils {
                 return false;
             }
         }
-        pixel >>= 24;
-        pixel &= 0xf0;
-        return (pixel > 0);
+        return ((pixel >> 24) & 0xf0) > 0;
     }
 
     private static boolean printThis(int ch) {

--- a/newcode/src/com/pclewis/mcpatcher/mod/FontUtils.java
+++ b/newcode/src/com/pclewis/mcpatcher/mod/FontUtils.java
@@ -73,6 +73,9 @@ public class FontUtils {
             if (charWidthf[ch] <= 0.0f) {
                 charWidthf[ch] = 2.0f;
             }
+            else if (charWidthf[ch] <= 7.99f) {
+                charWidthf[ch] = 7.99f;	
+            }
         }
         boolean[] isOverride = new boolean[charWidth.length];
         try {
@@ -112,7 +115,7 @@ public class FontUtils {
                     c = s.charAt(i + 1);
                     if (c == 'l' || c == 'L') {
                         isLink = true;
-                    } else if (c == 'r' || c == 'R') {
+                    } else if (c == 'r' || c == 'R' || (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
                         isLink = false;
                     }
                     cWidth = fontRenderer.getCharWidth(c);
@@ -132,7 +135,9 @@ public class FontUtils {
                 return false;
             }
         }
-        return (pixel & 0xff) > 0;
+        pixel >>= 24;
+        pixel &= 0xf0;
+        return (pixel > 0);
     }
 
     private static boolean printThis(int ch) {

--- a/newcode/src/com/pclewis/mcpatcher/mod/SuperTessellator.java
+++ b/newcode/src/com/pclewis/mcpatcher/mod/SuperTessellator.java
@@ -53,7 +53,7 @@ public class SuperTessellator extends Tessellator {
     void clearTessellators() {
         children.clear();
     }
-    
+
     private Field[] getFieldsToCopy() {
         int saveBufferSize;
         if (isForge) {

--- a/newcode/src/com/pclewis/mcpatcher/mod/TileOverride.java
+++ b/newcode/src/com/pclewis/mcpatcher/mod/TileOverride.java
@@ -150,7 +150,7 @@ abstract class TileOverride {
     }
 
     boolean requiresFace() {
-        return true;
+        return false;
     }
 
     final void error(String format, Object... params) {
@@ -275,6 +275,11 @@ abstract class TileOverride {
         }
 
         @Override
+        boolean requiresFace() {
+            return true;
+        }
+
+        @Override
         int getTileImpl(IBlockAccess blockAccess, Block block, int origTexture, int i, int j, int k, int face) {
             int[][] offsets = CTMUtils.NEIGHBOR_OFFSET[face];
             int neighborBits = 0;
@@ -334,7 +339,7 @@ abstract class TileOverride {
 
     final static class Vertical extends TileOverride {
         private static final int[] defaultTileMap = new int[]{
-            68, 69, 70, 71,
+            48, 32, 16, 0,
         };
 
         // Index into this array is formed from these bit values:

--- a/shared/src/com/pclewis/mcpatcher/MCPatcherUtils.java
+++ b/shared/src/com/pclewis/mcpatcher/MCPatcherUtils.java
@@ -9,7 +9,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.zip.ZipFile;
 
 /**
@@ -461,7 +460,7 @@ public class MCPatcherUtils {
     /**
      * Parse a comma-separated list of integers/ranges.
      *
-     * @param list comma-separated list, e.g., 2-4,5,8,12-20
+     * @param list     comma-separated list, e.g., 2-4,5,8,12-20
      * @param minValue smallest value allowed in the list
      * @param maxValue largest value allowed in the list
      * @return possibly empty integer array

--- a/src/com/pclewis/mcpatcher/AddFieldPatch.java
+++ b/src/com/pclewis/mcpatcher/AddFieldPatch.java
@@ -22,7 +22,7 @@ public class AddFieldPatch extends ClassPatch {
     /**
      * Add a new field.
      *
-     * @param fieldRef new field
+     * @param fieldRef    new field
      * @param accessFlags Java access flags (public, private, etc.).
      * @see javassist.bytecode.AccessFlag
      */
@@ -34,10 +34,10 @@ public class AddFieldPatch extends ClassPatch {
     /**
      * Add a new public, non-static field.
      *
-     * @deprecated
-     * @see #AddFieldPatch(FieldRef)
      * @param name field name
      * @param type field type descriptor
+     * @see #AddFieldPatch(FieldRef)
+     * @deprecated
      */
     public AddFieldPatch(String name, String type) {
         this(new FieldRef(null, name, type));
@@ -52,7 +52,7 @@ public class AddFieldPatch extends ClassPatch {
      * @see javassist.bytecode.AccessFlag
      */
     public AddFieldPatch(String name, String type, int accessFlags) {
-        this(new FieldRef(null, name,  type), accessFlags);
+        this(new FieldRef(null, name, type), accessFlags);
     }
 
     /**

--- a/src/com/pclewis/mcpatcher/AddMethodPatch.java
+++ b/src/com/pclewis/mcpatcher/AddMethodPatch.java
@@ -43,7 +43,7 @@ abstract public class AddMethodPatch extends ClassPatch {
     /**
      * Add a new method.
      *
-     * @param methodRef method
+     * @param methodRef   method
      * @param accessFlags Java access flags
      * @see javassist.bytecode.AccessFlag
      */
@@ -55,10 +55,10 @@ abstract public class AddMethodPatch extends ClassPatch {
     /**
      * Create an AddMethodPatch with given name and type.
      *
-     * @deprecated
-     * @see #AddMethodPatch(MethodRef)
      * @param name name of method
      * @param type Java type descriptor of method; may use deobfuscated names
+     * @see #AddMethodPatch(MethodRef)
+     * @deprecated
      */
     public AddMethodPatch(String name, String type) {
         this(new MethodRef(null, name, type), AccessFlag.PUBLIC);
@@ -67,12 +67,12 @@ abstract public class AddMethodPatch extends ClassPatch {
     /**
      * Create an AddMethodPatch with given name, type, and access flags.
      *
-     * @deprecated
-     * @see #AddMethodPatch(MethodRef, int)
      * @param name        name of method
      * @param type        Java type descriptor of method; may use deobfuscated names
      * @param accessFlags method access flags
+     * @see #AddMethodPatch(MethodRef, int)
      * @see javassist.bytecode.AccessFlag
+     * @deprecated
      */
     public AddMethodPatch(String name, String type, int accessFlags) {
         this(new MethodRef(null, name, type), accessFlags);

--- a/src/com/pclewis/mcpatcher/ClassMod.java
+++ b/src/com/pclewis/mcpatcher/ClassMod.java
@@ -445,20 +445,20 @@ abstract public class ClassMod implements PatchComponent {
         }
 
         /**
-         * @deprecated
-         * @see #FieldMapper(FieldRef...)
-         * @param names field names
+         * @param names      field names
          * @param descriptor field type
+         * @see #FieldMapper(FieldRef...)
+         * @deprecated
          */
         public FieldMapper(String[] names, String descriptor) {
             super(names, descriptor);
         }
 
         /**
-         * @deprecated
-         * @see #FieldMapper(FieldRef...)
-         * @param name field name
+         * @param name       field name
          * @param descriptor field type
+         * @see #FieldMapper(FieldRef...)
+         * @deprecated
          */
         public FieldMapper(String name, String descriptor) {
             super(name, descriptor);
@@ -487,20 +487,20 @@ abstract public class ClassMod implements PatchComponent {
         }
 
         /**
-         * @deprecated
-         * @see #MethodMapper(MethodRef...)
-         * @param names method names
+         * @param names      method names
          * @param descriptor method type
+         * @see #MethodMapper(MethodRef...)
+         * @deprecated
          */
         public MethodMapper(String[] names, String descriptor) {
             super(names, descriptor);
         }
 
         /**
-         * @deprecated
-         * @see #MethodMapper(MethodRef...)
-         * @param name method name
+         * @param name       method name
          * @param descriptor method type
+         * @see #MethodMapper(MethodRef...)
+         * @deprecated
          */
         public MethodMapper(String name, String descriptor) {
             super(name, descriptor);

--- a/src/com/pclewis/mcpatcher/mod/ConnectedTextures.java
+++ b/src/com/pclewis/mcpatcher/mod/ConnectedTextures.java
@@ -2,7 +2,6 @@ package com.pclewis.mcpatcher.mod;
 
 import com.pclewis.mcpatcher.*;
 import javassist.bytecode.AccessFlag;
-import javassist.bytecode.ClassFile;
 import javassist.bytecode.MethodInfo;
 
 import javax.swing.*;

--- a/src/com/pclewis/mcpatcher/mod/CustomColors.java
+++ b/src/com/pclewis/mcpatcher/mod/CustomColors.java
@@ -2750,7 +2750,7 @@ public class CustomColors extends Mod {
             classSignatures.add(new ConstSignature(0.1875));
             classSignatures.add(new ConstSignature(0.01));
 
-            final MethodRef renderBlockFallingSand = new MethodRef(getDeobfClass(), "renderBlockFallingSand", "(LBlock;LWorld;III" + (renderBlockFallingSandTakes4Ints ? "I" : "")  + ")V");
+            final MethodRef renderBlockFallingSand = new MethodRef(getDeobfClass(), "renderBlockFallingSand", "(LBlock;LWorld;III" + (renderBlockFallingSandTakes4Ints ? "I" : "") + ")V");
             final int renderBlockFallingSandOffset = renderBlockFallingSandTakes4Ints ? 1 : 0;
             final MethodRef setColorOpaque_F = new MethodRef("Tessellator", "setColorOpaque_F", "(FFF)V");
             final MethodRef renderBlockFluids = new MethodRef(getDeobfClass(), "renderBlockFluids", "(LBlock;III)Z");


### PR DESCRIPTION
Reads _Alpha_ instead of _Green_ channel when determining opacity. This allows automatic width detection to work with most fonts.
Automatic detection has been restricted to one character fullwidth, properties files will still override this.
Very large font textures (1024^2) will still have a single pixel-wide column of garbage at the edge of auto-detected fullwidth characters. (This now typically appears as dots after an 'M' or a '_' instead of "garbled" noise after anything wider than a '1')

The threshold for opacity has been moved to 16 from 0.

getStringWidthf resets bold ('link' ?) tracking for colour formatting codes as well, like the vanilla Minecraft fontRenderer outputs.

Signed-off-by: dluechoy dluechoy@gmail.com
